### PR TITLE
upgrade dependencies; add new rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export default [
         // The below pattern is covered by `import/no-relative-parent-imports`.
         // { name: "../*", message: "Don't use relative path to any parent direction." },
       ]],
+	    "n/no-extraneous-import": ["error", {allowModules: ["@eslint/js"]}],
       "import/order": ["warn", {
         groups: [
           "builtin",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,7 +39,8 @@ export default tseslint.config([
 		...configJs,
 		settings: {
 			...configJs.settings,
-			tsconfigPath: './jsconfig.json'
+			tsconfigPath: './jsconfig.json',
+			tryExtensions: ['.js', '.ts']
 		}
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,6 +67,8 @@ export default tseslint.config([
 			'no-restricted-globals': [ERROR, 'document', 'event', 'window', 'navigator'],
 			'sort-keys': [WARN, 'asc', {caseSensitive: false, minKeys: 20, natural: true}],
 
+			'n/no-extraneous-import': [ERROR, {allowModules: ['@eslint/js']}],
+
 			'typescript/naming-convention': [WARN, {selector: 'objectLiteralProperty', format: null}],
 			'typescript/no-magic-numbers': [
 				WARN,

--- a/eslint.format.config.mjs
+++ b/eslint.format.config.mjs
@@ -30,7 +30,12 @@ const configTs = getConfigTsFormat('warn', defaultOptions);
 
 export default tseslint.config([
 	{ignores: [...ignores, 'samples/', 'lib/']},
-	{linterOptions: {...linterOptions, reportUnusedInlineConfigs: OFF}},
+	{
+		linterOptions: {
+			...linterOptions,
+			reportUnusedDisableDirectives: OFF // For non-format rules
+		}
+	},
 	{
 		...configJs,
 		settings: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
 				"typescript": "^5.8.3",
 				"typescript-eslint": "^8.33.1"
 			},
+			"engines": {
+				"node": "^20.19.0 || 22.x || 24.x"
+			},
 			"optionalDependencies": {
 				"@eslint/markdown": "^6.4.0",
 				"@stylistic/eslint-plugin-js": "^4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
 				"eslint-plugin-import-x": "^4.11.0",
 				"eslint-plugin-n": "^17.17.0",
 				"globals": "^16.0.0",
-				"type-fest": "^4.40.1",
+				"type-fest": "^4.41.0",
 				"typescript": "^5.8.3",
-				"typescript-eslint": "^8.32.1"
+				"typescript-eslint": "^8.33.1"
 			},
 			"optionalDependencies": {
 				"@eslint/markdown": "^6.4.0",
@@ -40,7 +40,7 @@
 				"eslint-plugin-import-x": "^4.11.0",
 				"eslint-plugin-react": "^7.37.5",
 				"eslint-plugin-react-hooks": "^5.2.0",
-				"typescript-eslint": "^8.32.1"
+				"typescript-eslint": "^8.33.1"
 			},
 			"peerDependencies": {
 				"eslint": "^9.28.0",
@@ -594,17 +594,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
-			"integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.1.tgz",
+			"integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.32.1",
-				"@typescript-eslint/type-utils": "8.32.1",
-				"@typescript-eslint/utils": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1",
+				"@typescript-eslint/scope-manager": "8.33.1",
+				"@typescript-eslint/type-utils": "8.33.1",
+				"@typescript-eslint/utils": "8.33.1",
+				"@typescript-eslint/visitor-keys": "8.33.1",
 				"graphemer": "^1.4.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
@@ -618,15 +618,15 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+				"@typescript-eslint/parser": "^8.33.1",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -634,16 +634,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
-			"integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
+			"integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.32.1",
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/typescript-estree": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1",
+				"@typescript-eslint/scope-manager": "8.33.1",
+				"@typescript-eslint/types": "8.33.1",
+				"@typescript-eslint/typescript-estree": "8.33.1",
+				"@typescript-eslint/visitor-keys": "8.33.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -658,15 +658,37 @@
 				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
-		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
-			"integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
+			"integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1"
+				"@typescript-eslint/tsconfig-utils": "^8.33.1",
+				"@typescript-eslint/types": "^8.33.1",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
+			"integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.33.1",
+				"@typescript-eslint/visitor-keys": "8.33.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -676,15 +698,32 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
+			"integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
+			"devOptional": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
-			"integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.1.tgz",
+			"integrity": "sha512-1cG37d9xOkhlykom55WVwG2QRNC7YXlxMaMzqw2uPeJixBFfKWZgaP/hjAObqMN/u3fr5BrTwTnc31/L9jQ2ww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.32.1",
-				"@typescript-eslint/utils": "8.32.1",
+				"@typescript-eslint/typescript-estree": "8.33.1",
+				"@typescript-eslint/utils": "8.33.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -701,9 +740,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
-			"integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
+			"integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -715,14 +754,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
-			"integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
+			"integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1",
+				"@typescript-eslint/project-service": "8.33.1",
+				"@typescript-eslint/tsconfig-utils": "8.33.1",
+				"@typescript-eslint/types": "8.33.1",
+				"@typescript-eslint/visitor-keys": "8.33.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -742,16 +783,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
-			"integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
+			"integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.32.1",
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/typescript-estree": "8.32.1"
+				"@typescript-eslint/scope-manager": "8.33.1",
+				"@typescript-eslint/types": "8.33.1",
+				"@typescript-eslint/typescript-estree": "8.33.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -766,13 +807,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
-			"integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
+			"integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/types": "8.33.1",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
@@ -5388,15 +5429,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
-			"integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
+			"version": "8.33.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.33.1.tgz",
+			"integrity": "sha512-AgRnV4sKkWOiZ0Kjbnf5ytTJXMUZQ0qhSVdQtDNYLPLnjsATEYhaO94GlRQwi4t4gO8FfjM6NnikHeKjUm8D7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.32.1",
-				"@typescript-eslint/parser": "8.32.1",
-				"@typescript-eslint/utils": "8.32.1"
+				"@typescript-eslint/eslint-plugin": "8.33.1",
+				"@typescript-eslint/parser": "8.33.1",
+				"@typescript-eslint/utils": "8.33.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@eslint-community/eslint-plugin-eslint-comments": "~4.5.0",
 				"@stylistic/eslint-plugin": "~4.4.1",
-				"eslint-plugin-n": "~17.17.0",
+				"eslint-plugin-n": "~17.19.0",
 				"eslint-plugin-promise": "~7.2.1",
 				"globals": "^16.1.0"
 			},
@@ -23,7 +23,7 @@
 				"eslint-import-resolver-typescript": "^4.3.4",
 				"eslint-plugin-import": "~2.31.0",
 				"eslint-plugin-import-x": "^4.11.0",
-				"eslint-plugin-n": "^17.17.0",
+				"eslint-plugin-n": "^17.19.0",
 				"globals": "^16.0.0",
 				"type-fest": "^4.41.0",
 				"typescript": "^5.8.3",
@@ -2150,20 +2150,22 @@
 			}
 		},
 		"node_modules/eslint-plugin-n": {
-			"version": "17.17.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.17.0.tgz",
-			"integrity": "sha512-2VvPK7Mo73z1rDFb6pTvkH6kFibAmnTubFq5l83vePxu0WiY1s0LOtj2WHb6Sa40R3w4mnh8GFYbHBQyMlotKw==",
+			"version": "17.19.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.19.0.tgz",
+			"integrity": "sha512-qxn1NaDHtizbhVAPpbMT8wWFaLtPnwhfN/e+chdu2i6Vgzmo/tGM62tcJ1Hf7J5Ie4dhse3DOPMmDxduzfifzw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.5.0",
+				"@typescript-eslint/utils": "^8.26.1",
 				"enhanced-resolve": "^5.17.1",
 				"eslint-plugin-es-x": "^7.8.0",
 				"get-tsconfig": "^4.8.1",
 				"globals": "^15.11.0",
 				"ignore": "^5.3.2",
 				"minimatch": "^9.0.5",
-				"semver": "^7.6.3"
+				"semver": "^7.6.3",
+				"ts-declaration-location": "^1.0.6"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5289,6 +5291,29 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.8.4"
+			}
+		},
+		"node_modules/ts-declaration-location": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+			"integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "ko-fi",
+					"url": "https://ko-fi.com/rebeccastevens"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"picomatch": "^4.0.2"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.0.0"
 			}
 		},
 		"node_modules/tsconfig-paths": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
 				"@eslint/markdown": "^6.4.0",
 				"@stylistic/eslint-plugin": "^4.2.0",
-				"eslint": "~9.27.0",
+				"eslint": "^9.28.0",
 				"eslint-import-resolver-typescript": "^4.3.4",
 				"eslint-plugin-import": "~2.31.0",
 				"eslint-plugin-import-x": "^4.11.0",
@@ -43,7 +43,7 @@
 				"typescript-eslint": "^8.32.1"
 			},
 			"peerDependencies": {
-				"eslint": "~9.27.0",
+				"eslint": "^9.28.0",
 				"typescript": "~5.8.3"
 			}
 		},
@@ -256,9 +256,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.27.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
-			"integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
+			"version": "9.28.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+			"integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1820,9 +1820,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
-			"integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
+			"version": "9.28.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
+			"integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
@@ -1831,7 +1831,7 @@
 				"@eslint/config-helpers": "^0.2.1",
 				"@eslint/core": "^0.14.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.27.0",
+				"@eslint/js": "9.28.0",
 				"@eslint/plugin-kit": "^0.3.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "./LICENSE",
 			"dependencies": {
 				"@eslint-community/eslint-plugin-eslint-comments": "~4.5.0",
-				"@eslint/js": "~9.27.0",
 				"@stylistic/eslint-plugin": "~4.2.0",
 				"eslint-plugin-n": "~17.17.0",
 				"eslint-plugin-promise": "~7.2.1",
@@ -18,7 +17,6 @@
 			},
 			"devDependencies": {
 				"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
-				"@eslint/js": "~9.27.0",
 				"@eslint/markdown": "^6.4.0",
 				"@stylistic/eslint-plugin": "^4.2.0",
 				"eslint": "~9.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "./LICENSE",
 			"dependencies": {
 				"@eslint-community/eslint-plugin-eslint-comments": "~4.5.0",
-				"@stylistic/eslint-plugin": "~4.2.0",
+				"@stylistic/eslint-plugin": "~4.4.1",
 				"eslint-plugin-n": "~17.17.0",
 				"eslint-plugin-promise": "~7.2.1",
 				"globals": "^16.1.0"
@@ -18,7 +18,7 @@
 			"devDependencies": {
 				"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
 				"@eslint/markdown": "^6.4.0",
-				"@stylistic/eslint-plugin": "^4.2.0",
+				"@stylistic/eslint-plugin": "~4.4.1",
 				"eslint": "^9.28.0",
 				"eslint-import-resolver-typescript": "^4.3.4",
 				"eslint-plugin-import": "~2.31.0",
@@ -31,10 +31,10 @@
 			},
 			"optionalDependencies": {
 				"@eslint/markdown": "^6.4.0",
-				"@stylistic/eslint-plugin-js": "^4.2.0",
-				"@stylistic/eslint-plugin-jsx": "^4.2.0",
-				"@stylistic/eslint-plugin-plus": "^4.2.0",
-				"@stylistic/eslint-plugin-ts": "^4.2.0",
+				"@stylistic/eslint-plugin-js": "^4.4.1",
+				"@stylistic/eslint-plugin-jsx": "^4.4.1",
+				"@stylistic/eslint-plugin-plus": "^4.4.1",
+				"@stylistic/eslint-plugin-ts": "^4.4.1",
 				"eslint-import-resolver-typescript": "^4.3.4",
 				"eslint-plugin-import": "~2.31.0",
 				"eslint-plugin-import-x": "^4.11.0",
@@ -442,13 +442,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@stylistic/eslint-plugin": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.2.0.tgz",
-			"integrity": "sha512-8hXezgz7jexGHdo5WN6JBEIPHCSFyyU4vgbxevu4YLVS5vl+sxqAAGyXSzfNDyR6xMNSH5H1x67nsXcYMOHtZA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.4.1.tgz",
+			"integrity": "sha512-CEigAk7eOLyHvdgmpZsKFwtiqS2wFwI1fn4j09IU9GmD4euFM4jEBAViWeCqaNLlbX2k2+A/Fq9cje4HQBXuJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "^8.23.0",
+				"@typescript-eslint/utils": "^8.32.1",
 				"eslint-visitor-keys": "^4.2.0",
 				"espree": "^10.3.0",
 				"estraverse": "^5.3.0",
@@ -462,9 +462,9 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-js": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.2.0.tgz",
-			"integrity": "sha512-MiJr6wvyzMYl/wElmj8Jns8zH7Q1w8XoVtm+WM6yDaTrfxryMyb8n0CMxt82fo42RoLIfxAEtM6tmQVxqhk0/A==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.4.1.tgz",
+			"integrity": "sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -479,9 +479,9 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-jsx": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-4.2.0.tgz",
-			"integrity": "sha512-V+AtcVs0a3ck2IWWH/fd/+TmOYSgBJlsJXIR65+3kqgNi3p3pPfo9C8nhRsU/KlcSwhnzyx+Z/kEcuWCMZtTcA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-4.4.1.tgz",
+			"integrity": "sha512-83SInq4u7z71vWwGG+6ViOtlOmZ6tSrDkMPhrvdBBTGMLA0gs22WSdhQ4vZP3oJ5Xg4ythvqeUiFSedvVxzhyA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -498,9 +498,9 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-plus": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-4.2.0.tgz",
-			"integrity": "sha512-w7HArI09lCB7u9hj0ZXojY49iQmcmL8mJKkZ3EXCRCy6nlM8AeHZCFxNDXJo4EW/sP08RiaspXEbL9ZtDs4cPQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-4.4.1.tgz",
+			"integrity": "sha512-4w2Ktg7OuJrn0QwJPdTWmrweJ91UoIUEiSPLUVTurAR+Qx9rLHGnycAocUcoRMtPRmCNmw1BP61JKsl7Jug38g==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -512,13 +512,13 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-ts": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-4.2.0.tgz",
-			"integrity": "sha512-j2o2GvOx9v66x8hmp/HJ+0T+nOppiO5ycGsCkifh7JPGgjxEhpkGmIGx3RWsoxpWbad3VCX8e8/T8n3+7ze1Zg==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-4.4.1.tgz",
+			"integrity": "sha512-2r6cLcmdF6til66lx8esBYvBvsn7xCmLT50gw/n1rGGlTq/OxeNjBIh4c3VEaDGMa/5TybrZTia6sQUHdIWx1w==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "^8.23.0",
+				"@typescript-eslint/utils": "^8.32.1",
 				"eslint-visitor-keys": "^4.2.0",
 				"espree": "^10.3.0"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "./LICENSE",
 			"dependencies": {
 				"@eslint-community/eslint-plugin-eslint-comments": "~4.5.0",
-				"@eslint/js": "~9.26.0",
+				"@eslint/js": "~9.27.0",
 				"@stylistic/eslint-plugin": "~4.2.0",
 				"eslint-plugin-n": "~17.17.0",
 				"eslint-plugin-promise": "~7.2.1",
@@ -18,10 +18,10 @@
 			},
 			"devDependencies": {
 				"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
-				"@eslint/js": "^9.26.0",
+				"@eslint/js": "~9.27.0",
 				"@eslint/markdown": "^6.4.0",
 				"@stylistic/eslint-plugin": "^4.2.0",
-				"eslint": "^9.26.0",
+				"eslint": "~9.27.0",
 				"eslint-import-resolver-typescript": "^4.3.4",
 				"eslint-plugin-import": "~2.31.0",
 				"eslint-plugin-import-x": "^4.11.0",
@@ -45,7 +45,7 @@
 				"typescript-eslint": "^8.32.1"
 			},
 			"peerDependencies": {
-				"eslint": "^9.26.0",
+				"eslint": "~9.27.0",
 				"typescript": "~5.8.3"
 			}
 		},
@@ -258,12 +258,15 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.26.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
-			"integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
+			"version": "9.27.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
+			"integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
 			}
 		},
 		"node_modules/@eslint/markdown": {
@@ -298,6 +301,7 @@
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
 			"integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/core": "^0.13.0",
@@ -311,6 +315,7 @@
 			"version": "0.13.0",
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
 			"integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
@@ -378,27 +383,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
-			}
-		},
-		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.1.tgz",
-			"integrity": "sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==",
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^1.0.5",
-				"cors": "^2.8.5",
-				"cross-spawn": "^7.0.3",
-				"eventsource": "^3.0.2",
-				"express": "^5.0.1",
-				"express-rate-limit": "^7.5.0",
-				"pkce-challenge": "^5.0.0",
-				"raw-body": "^3.0.0",
-				"zod": "^3.23.8",
-				"zod-to-json-schema": "^3.24.1"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -1042,19 +1026,6 @@
 				"win32"
 			]
 		},
-		"node_modules/accepts": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-types": "^3.0.0",
-				"negotiator": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/acorn": {
 			"version": "8.14.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1303,26 +1274,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT"
 		},
-		"node_modules/body-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-			"integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
-				"debug": "^4.4.0",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.6.3",
-				"on-finished": "^2.4.1",
-				"qs": "^6.14.0",
-				"raw-body": "^3.0.0",
-				"type-is": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1344,15 +1295,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/call-bind": {
@@ -1378,6 +1320,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -1391,6 +1334,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -1483,58 +1427,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"license": "MIT"
-		},
-		"node_modules/content-disposition": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-			"integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/content-type": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-signature": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.6.0"
-			}
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"license": "MIT",
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -1677,15 +1569,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/depd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/dequal": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1727,6 +1610,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
@@ -1735,21 +1619,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-			"license": "MIT"
-		},
-		"node_modules/encodeurl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -1836,6 +1705,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -1845,6 +1715,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -1882,6 +1753,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
 			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -1937,12 +1809,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-			"license": "MIT"
-		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1956,23 +1822,22 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.26.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
-			"integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
+			"version": "9.27.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
+			"integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
 				"@eslint/config-array": "^0.20.0",
 				"@eslint/config-helpers": "^0.2.1",
-				"@eslint/core": "^0.13.0",
+				"@eslint/core": "^0.14.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.26.0",
-				"@eslint/plugin-kit": "^0.2.8",
+				"@eslint/js": "9.27.0",
+				"@eslint/plugin-kit": "^0.3.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
-				"@modelcontextprotocol/sdk": "^1.8.0",
 				"@types/estree": "^1.0.6",
 				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
@@ -1996,8 +1861,7 @@
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"zod": "^3.24.2"
+				"optionator": "^0.9.3"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -2430,12 +2294,25 @@
 			}
 		},
 		"node_modules/eslint/node_modules/@eslint/core": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-			"integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+			"integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/eslint/node_modules/@eslint/plugin-kit": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+			"integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.14.0",
+				"levn": "^0.4.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2520,93 +2397,6 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/eventsource": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
-			"integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
-			"license": "MIT",
-			"dependencies": {
-				"eventsource-parser": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/eventsource-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-			"integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/express": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-			"integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "^2.0.0",
-				"body-parser": "^2.2.0",
-				"content-disposition": "^1.0.0",
-				"content-type": "^1.0.5",
-				"cookie": "^0.7.1",
-				"cookie-signature": "^1.2.1",
-				"debug": "^4.4.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"finalhandler": "^2.1.0",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"merge-descriptors": "^2.0.0",
-				"mime-types": "^3.0.0",
-				"on-finished": "^2.4.1",
-				"once": "^1.4.0",
-				"parseurl": "^1.3.3",
-				"proxy-addr": "^2.0.7",
-				"qs": "^6.14.0",
-				"range-parser": "^1.2.1",
-				"router": "^2.2.0",
-				"send": "^1.1.0",
-				"serve-static": "^2.2.0",
-				"statuses": "^2.0.1",
-				"type-is": "^2.0.1",
-				"vary": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/express-rate-limit": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-			"integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/express-rate-limit"
-			},
-			"peerDependencies": {
-				"express": "^4.11 || 5 || ^5.0.0-beta.1"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -2721,23 +2511,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/finalhandler": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-			"integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"on-finished": "^2.4.1",
-				"parseurl": "^1.3.3",
-				"statuses": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2798,28 +2571,11 @@
 				"node": ">=0.4.x"
 			}
 		},
-		"node_modules/forwarded": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/fresh": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2860,6 +2616,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -2884,6 +2641,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
@@ -2970,6 +2728,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3047,6 +2806,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3075,40 +2835,13 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-			"license": "MIT",
-			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ignore": {
@@ -3145,12 +2878,6 @@
 				"node": ">=0.8.19"
 			}
 		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"license": "ISC"
-		},
 		"node_modules/internal-slot": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -3164,15 +2891,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -3415,12 +3133,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/is-promise": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-			"license": "MIT"
 		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
@@ -3746,6 +3458,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3994,27 +3707,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/media-typer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/merge-descriptors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/merge2": {
@@ -4662,27 +4354,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4737,20 +4408,12 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"license": "MIT"
 		},
-		"node_modules/negotiator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4759,6 +4422,7 @@
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -4867,27 +4531,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/on-finished": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-			"license": "MIT",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"license": "ISC",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4965,15 +4608,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4999,15 +4633,6 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
-		"node_modules/path-to-regexp": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-			"integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/picomatch": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -5019,15 +4644,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pkce-challenge": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-			"integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/possible-typed-array-names": {
@@ -5061,19 +4677,6 @@
 				"react-is": "^16.13.1"
 			}
 		},
-		"node_modules/proxy-addr": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-			"license": "MIT",
-			"dependencies": {
-				"forwarded": "0.2.0",
-				"ipaddr.js": "1.9.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5081,21 +4684,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -5118,30 +4706,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-			"integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.6.3",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/react-is": {
 			"version": "16.13.1",
@@ -5245,22 +4809,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/router": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"depd": "^2.0.0",
-				"is-promise": "^4.0.0",
-				"parseurl": "^1.3.3",
-				"path-to-regexp": "^8.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5305,26 +4853,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/safe-push-apply": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5360,12 +4888,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"license": "MIT"
-		},
 		"node_modules/semver": {
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -5377,43 +4899,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/send": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-			"integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.5",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"mime-types": "^3.0.1",
-				"ms": "^2.1.3",
-				"on-finished": "^2.4.1",
-				"range-parser": "^1.2.1",
-				"statuses": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/serve-static": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-			"integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
-			"license": "MIT",
-			"dependencies": {
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"parseurl": "^1.3.3",
-				"send": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 18"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -5465,12 +4950,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-			"license": "ISC"
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5496,6 +4975,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
 			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -5515,6 +4995,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
 			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -5531,6 +5012,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
 			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -5549,6 +5031,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
 			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -5570,15 +5053,6 @@
 			"integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/string.prototype.matchall": {
 			"version": "4.0.12",
@@ -5765,15 +5239,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
 		"node_modules/ts-api-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5830,20 +5295,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/type-is": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^1.0.5",
-				"media-typer": "^1.1.0",
-				"mime-types": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/typed-array-buffer": {
@@ -6039,15 +5490,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/unrs-resolver": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.2.tgz",
@@ -6088,15 +5530,6 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/which": {
@@ -6212,12 +5645,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"license": "ISC"
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -6228,24 +5655,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/zod": {
-			"version": "3.24.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-			"integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.24.5",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-			"integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.24.1"
 			}
 		},
 		"node_modules/zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,15 +16,11 @@
 				"globals": "^16.1.0"
 			},
 			"devDependencies": {
-				"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
 				"@eslint/markdown": "^6.4.0",
-				"@stylistic/eslint-plugin": "~4.4.1",
 				"eslint": "^9.28.0",
 				"eslint-import-resolver-typescript": "^4.3.4",
 				"eslint-plugin-import": "~2.31.0",
 				"eslint-plugin-import-x": "^4.11.0",
-				"eslint-plugin-n": "^17.19.0",
-				"globals": "^16.0.0",
 				"type-fest": "^4.41.0",
 				"typescript": "^5.8.3",
 				"typescript-eslint": "^8.33.1"
@@ -85,7 +81,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.5.0.tgz",
 			"integrity": "sha512-MAhuTKlr4y/CE3WYX26raZjy+I/kS2PLKSzvfmDCGrBLTFHOYwqROZdr4XwPgXwX3K9rjzMr4pSmUWGnzsUyMg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"escape-string-regexp": "^4.0.0",
@@ -400,7 +395,6 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -414,7 +408,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -424,7 +417,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -445,7 +437,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.4.1.tgz",
 			"integrity": "sha512-CEigAk7eOLyHvdgmpZsKFwtiqS2wFwI1fn4j09IU9GmD4euFM4jEBAViWeCqaNLlbX2k2+A/Fq9cje4HQBXuJQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/utils": "^8.32.1",
@@ -662,7 +653,6 @@
 			"version": "8.33.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
 			"integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/tsconfig-utils": "^8.33.1",
@@ -684,7 +674,6 @@
 			"version": "8.33.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
 			"integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/types": "8.33.1",
@@ -702,7 +691,6 @@
 			"version": "8.33.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
 			"integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -743,7 +731,6 @@
 			"version": "8.33.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
 			"integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -757,7 +744,6 @@
 			"version": "8.33.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
 			"integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/project-service": "8.33.1",
@@ -786,7 +772,6 @@
 			"version": "8.33.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
 			"integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
@@ -810,7 +795,6 @@
 			"version": "8.33.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
 			"integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/types": "8.33.1",
@@ -1317,7 +1301,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -1327,7 +1310,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -1664,7 +1646,6 @@
 			"version": "5.18.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
 			"integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -1924,7 +1905,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
 			"integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.5.4"
@@ -2024,7 +2004,6 @@
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
 			"integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
-			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/ota-meshi",
 				"https://opencollective.com/eslint"
@@ -2153,7 +2132,6 @@
 			"version": "17.19.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.19.0.tgz",
 			"integrity": "sha512-qxn1NaDHtizbhVAPpbMT8wWFaLtPnwhfN/e+chdu2i6Vgzmo/tGM62tcJ1Hf7J5Ie4dhse3DOPMmDxduzfifzw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.5.0",
@@ -2181,7 +2159,6 @@
 			"version": "15.15.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
 			"integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -2450,7 +2427,6 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
 			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -2467,7 +2443,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -2492,7 +2467,6 @@
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
 			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -2543,7 +2517,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -2714,7 +2687,6 @@
 			"version": "4.10.0",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
 			"integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -2739,7 +2711,6 @@
 			"version": "16.1.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
 			"integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -2782,7 +2753,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/graphemer": {
@@ -3152,7 +3122,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -3754,7 +3723,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -4372,7 +4340,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -4386,7 +4353,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -4399,7 +4365,6 @@
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
 			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -4678,7 +4643,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -4731,7 +4695,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4833,7 +4796,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
 			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -4843,7 +4805,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
 			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -4854,7 +4815,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4933,7 +4893,6 @@
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
 			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-			"devOptional": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -5244,7 +5203,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -5271,7 +5229,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -5284,7 +5241,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
 			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.12"
@@ -5297,7 +5253,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
 			"integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "ko-fi",
@@ -5443,7 +5398,6 @@
 			"version": "5.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -46,17 +46,17 @@
 	},
 	"dependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "~4.5.0",
-		"@stylistic/eslint-plugin": "~4.2.0",
+		"@stylistic/eslint-plugin": "~4.4.1",
 		"eslint-plugin-n": "~17.17.0",
 		"eslint-plugin-promise": "~7.2.1",
 		"globals": "^16.1.0"
 	},
 	"optionalDependencies": {
 		"@eslint/markdown": "^6.4.0",
-		"@stylistic/eslint-plugin-js": "^4.2.0",
-		"@stylistic/eslint-plugin-jsx": "^4.2.0",
-		"@stylistic/eslint-plugin-plus": "^4.2.0",
-		"@stylistic/eslint-plugin-ts": "^4.2.0",
+		"@stylistic/eslint-plugin-js": "^4.4.1",
+		"@stylistic/eslint-plugin-jsx": "^4.4.1",
+		"@stylistic/eslint-plugin-plus": "^4.4.1",
+		"@stylistic/eslint-plugin-ts": "^4.4.1",
 		"eslint-import-resolver-typescript": "^4.3.4",
 		"eslint-plugin-import": "~2.31.0",
 		"eslint-plugin-import-x": "^4.11.0",
@@ -67,7 +67,7 @@
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
 		"@eslint/markdown": "^6.4.0",
-		"@stylistic/eslint-plugin": "^4.2.0",
+		"@stylistic/eslint-plugin": "~4.4.1",
 		"eslint": "^9.28.0",
 		"eslint-import-resolver-typescript": "^4.3.4",
 		"eslint-plugin-import": "~2.31.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"eslint-plugin-import-x": "^4.11.0",
 		"eslint-plugin-react": "^7.37.5",
 		"eslint-plugin-react-hooks": "^5.2.0",
-		"typescript-eslint": "^8.32.1"
+		"typescript-eslint": "^8.33.1"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -74,9 +74,9 @@
 		"eslint-plugin-import-x": "^4.11.0",
 		"eslint-plugin-n": "^17.17.0",
 		"globals": "^16.0.0",
-		"type-fest": "^4.40.1",
+		"type-fest": "^4.41.0",
 		"typescript": "^5.8.3",
-		"typescript-eslint": "^8.32.1"
+		"typescript-eslint": "^8.33.1"
 	},
 	"type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
 	},
 	"dependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "~4.5.0",
-		"@eslint/js": "~9.27.0",
 		"@stylistic/eslint-plugin": "~4.2.0",
 		"eslint-plugin-n": "~17.17.0",
 		"eslint-plugin-promise": "~7.2.1",
@@ -67,7 +66,6 @@
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
-		"@eslint/js": "~9.27.0",
 		"@eslint/markdown": "^6.4.0",
 		"@stylistic/eslint-plugin": "^4.2.0",
 		"eslint": "~9.27.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	"dependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "~4.5.0",
 		"@stylistic/eslint-plugin": "~4.4.1",
-		"eslint-plugin-n": "~17.17.0",
+		"eslint-plugin-n": "~17.19.0",
 		"eslint-plugin-promise": "~7.2.1",
 		"globals": "^16.1.0"
 	},
@@ -72,7 +72,7 @@
 		"eslint-import-resolver-typescript": "^4.3.4",
 		"eslint-plugin-import": "~2.31.0",
 		"eslint-plugin-import-x": "^4.11.0",
-		"eslint-plugin-n": "^17.17.0",
+		"eslint-plugin-n": "^17.19.0",
 		"globals": "^16.0.0",
 		"type-fest": "^4.41.0",
 		"typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
 		"url": "https://github.com/u-sho/eslint-config/issues"
 	},
 	"homepage": "https://github.com/u-sho/eslint-config#readme",
+	"engines": {
+		"node": "^20.19.0 || 22.x || 24.x"
+	},
 	"peerDependencies": {
 		"eslint": "^9.28.0",
 		"typescript": "~5.8.3"

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
 	},
 	"homepage": "https://github.com/u-sho/eslint-config#readme",
 	"peerDependencies": {
-		"eslint": "^9.26.0",
+		"eslint": "~9.27.0",
 		"typescript": "~5.8.3"
 	},
 	"dependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "~4.5.0",
-		"@eslint/js": "~9.26.0",
+		"@eslint/js": "~9.27.0",
 		"@stylistic/eslint-plugin": "~4.2.0",
 		"eslint-plugin-n": "~17.17.0",
 		"eslint-plugin-promise": "~7.2.1",
@@ -67,10 +67,10 @@
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
-		"@eslint/js": "^9.26.0",
+		"@eslint/js": "~9.27.0",
 		"@eslint/markdown": "^6.4.0",
 		"@stylistic/eslint-plugin": "^4.2.0",
-		"eslint": "^9.26.0",
+		"eslint": "~9.27.0",
 		"eslint-import-resolver-typescript": "^4.3.4",
 		"eslint-plugin-import": "~2.31.0",
 		"eslint-plugin-import-x": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -65,15 +65,11 @@
 		"typescript-eslint": "^8.33.1"
 	},
 	"devDependencies": {
-		"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
 		"@eslint/markdown": "^6.4.0",
-		"@stylistic/eslint-plugin": "~4.4.1",
 		"eslint": "^9.28.0",
 		"eslint-import-resolver-typescript": "^4.3.4",
 		"eslint-plugin-import": "~2.31.0",
 		"eslint-plugin-import-x": "^4.11.0",
-		"eslint-plugin-n": "^17.19.0",
-		"globals": "^16.0.0",
 		"type-fest": "^4.41.0",
 		"typescript": "^5.8.3",
 		"typescript-eslint": "^8.33.1"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/u-sho/eslint-config#readme",
 	"peerDependencies": {
-		"eslint": "~9.27.0",
+		"eslint": "^9.28.0",
 		"typescript": "~5.8.3"
 	},
 	"dependencies": {
@@ -68,7 +68,7 @@
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
 		"@eslint/markdown": "^6.4.0",
 		"@stylistic/eslint-plugin": "^4.2.0",
-		"eslint": "~9.27.0",
+		"eslint": "^9.28.0",
 		"eslint-import-resolver-typescript": "^4.3.4",
 		"eslint-plugin-import": "~2.31.0",
 		"eslint-plugin-import-x": "^4.11.0",

--- a/plugin-configs/@eslint/js/rules/possible-problems.js
+++ b/plugin-configs/@eslint/js/rules/possible-problems.js
@@ -138,8 +138,11 @@ export default (logLevel = 'error', formatLogLevel = 'warn', {semi = true} = {})
 	// Disallow template literal placeholder syntax in regular strings
 	'no-template-curly-in-string': logLevel,
 
-	// Disallow this/super before calling super() in constructors
+	// Disallow `this`/`super` before calling `super()` in constructors
 	'no-this-before-super': logLevel,
+
+	// Disallow `let` or `var` variables that are read but never assigned
+	'no-unassigned-vars': logLevel,
 
 	// Disallow the use of undeclared variables unless mentioned in `/*global */` comments
 	'no-undef': 'error',

--- a/plugin-configs/@eslint/js/rules/suggestions.js
+++ b/plugin-configs/@eslint/js/rules/suggestions.js
@@ -119,7 +119,7 @@ export default (
 	'max-nested-callbacks': ['warn', {max: Infinity === complexityDepth ? 2 : complexityDepth}],
 
 	// Enforce a maximum number of parameters in function definitions
-	'max-params': logLevel, // `@typescript-eslint/max-params` rule is used
+	'max-params': [logLevel, {countVoidThis: true}], // `@typescript-eslint/max-params` rule is used
 
 	// Enforce a maximum number of statements allowed in function blocks
 	// eslint-disable-next-line 'typescript/no-magic-numbers' -- because statements are magic

--- a/plugin-configs/@eslint/js/rules/suggestions.js
+++ b/plugin-configs/@eslint/js/rules/suggestions.js
@@ -44,8 +44,7 @@ export default (
 	// Enforce consistent naming when capturing the current execution context
 	'consistent-this': [logLevel, 'self'],
 
-	/* Enforce consistent brace style for all control statements
-	   @ts-expect-error 2322: One of type definition or document is wrong. */
+	// Enforce consistent brace style for all control statements
 	'curly': [formatLogLevel, 'multi-or-nest', 'consistent'],
 
 	// Require default cases in switch statements
@@ -222,9 +221,14 @@ export default (
 	'no-loop-func': logLevel, // `@typescript-eslint/no-loop-func` rule is used
 
 	/* Disallow magic numbers
-		'@typescript-eslint/no-magic-numbers' rule is used.
-	   @ts-expect-error 2353: See https://eslint.org/docs/latest/rules/no-magic-numbers#ignoredefaultvalues */
-	'no-magic-numbers': [formatLogLevel, {enforceConst: true, ignore: [1], ignoreDefaultValues: true}],
+		'@typescript-eslint/no-magic-numbers' rule is used. */
+	'no-magic-numbers': [formatLogLevel, {enforceConst                 : true,
+	/* eslint-disable @stylistic/indent */ignore                       : [0, 1],
+	// @ts-expect-error 2353: See https://eslint.org/docs/latest/rules/no-magic-numbers#ignoredefaultvalues
+	                                      ignoreDefaultValues          : true,
+	                                      ignoreEnums                  : true,
+	                                      ignoreNumericLiteralTypes    : true,
+	/* eslint-enable @stylistic/indent */ ignoreReadonlyClassProperties: true}],
 
 	// Disallow use of chained assignment expressions
 	'no-multi-assign': formatLogLevel,

--- a/plugin-configs/@eslint/markdown/all.js
+++ b/plugin-configs/@eslint/markdown/all.js
@@ -4,8 +4,7 @@
  */
 
 // @ts-check
-/* eslint @stylistic/array-bracket-newline: ['warn', 'consistent']       -- good to understand. */
-/* eslint no-useless-escape: 'off' -- see `eslint-plugin-import` docs */
+/* eslint @stylistic/array-bracket-newline: ['warn', 'consistent'] -- good to understand. */
 
 import markdownPlugin from '@eslint/markdown';
 import markdownPluginRules from './rules/all.js';

--- a/plugin-configs/@stylistic/rules/additional.js
+++ b/plugin-configs/@stylistic/rules/additional.js
@@ -21,7 +21,7 @@ export default (
 	'@stylistic/plus/curly-newline': [formatLogLevel, {consistent: true, minElements: short ? 2 : 1}],
 
 	/* [formatLogLevel, {
-		// @ts-ignore IfStatement replaced to IfStatementConsequent or IfStatementAlternative
+		// @ts-expect-error 2561: IfStatement replaced to IfStatementConsequent or IfStatementAlternative
 		IfStatement          : {multiline: true, consistent: true},
 		ForStatement         : 'always',
 		ForInStatement       : 'always',

--- a/plugin-configs/@stylistic/rules/default.js
+++ b/plugin-configs/@stylistic/rules/default.js
@@ -5,8 +5,6 @@
  */
 
 // @ts-check
-/* eslint @stylistic/array-bracket-newline: ['warn', 'consistent']       -- good to understand. */
-/* eslint no-useless-escape: 'off' -- see `eslint-plugin-import` docs */
 /* eslint sort-keys: 'off' -- grouping the same rules */
 
 

--- a/plugin-configs/@stylistic/rules/default.js
+++ b/plugin-configs/@stylistic/rules/default.js
@@ -104,8 +104,8 @@ export default (
 		'@stylistic/curly-newline': [formatLogLevel, {consistent: true, minElements: short ? 2 : 1}],
 
 		/* [formatLogLevel, {
-				// @ts-ignore IfStatement replaced to IfStatementConsequent or IfStatementAlternative
-			IfStatement: {multiline: true, consistent: true},
+			// @ts-expect-error 2561: IfStatement replaced to IfStatementConsequent or IfStatementAlternative
+			IfStatement     : {multiline: true, consistent: true},
 			ForStatement    : 'always',
 			ForInStatement  : 'always',
 			ForOfStatement  : 'always',
@@ -122,7 +122,7 @@ export default (
 			FunctionDeclaration: {consistent: true, minElements: short ? 2 : 1},
 			FunctionExpression : {consistent: true, minElements: short ? 2 : 1},
 			Property           : {multiline: true},
-			ClassBody: short ? {multiline: true} : 'always',
+			ClassBody          : short ? {multiline: true} : 'always',
 
 			StaticBlock  : {multiline: true},
 			WithStatement: {multiline: true},

--- a/plugin-configs/@typescript-eslint/rules/others.js
+++ b/plugin-configs/@typescript-eslint/rules/others.js
@@ -91,7 +91,7 @@ export default (
 	// Disallow magic numbers
 	'no-magic-numbers'                   : 0,
 	'@typescript-eslint/no-magic-numbers': [formatLogLevel, {enforceConst                 : true,
-	/* eslint-disable @stylistic/indent                   */ ignore                       : [1],
+	/* eslint-disable @stylistic/indent                   */ ignore                       : [0, 1],
 	                                                         ignoreDefaultValues          : true,
 	                                                         ignoreEnums                  : true,
 	                                                         ignoreNumericLiteralTypes    : true,

--- a/plugin-configs/eslint-plugin-import/all.js
+++ b/plugin-configs/eslint-plugin-import/all.js
@@ -5,8 +5,7 @@
  */
 
 // @ts-check
-/* eslint @stylistic/array-bracket-newline: ['warn', 'consistent']       -- good to understand. */
-/* eslint no-useless-escape: 'off' -- see `eslint-plugin-import` docs */
+/* eslint @stylistic/array-bracket-newline: ['warn', 'consistent'] -- good to understand. */
 
 import importPlugin from 'eslint-plugin-import-x';
 
@@ -83,12 +82,15 @@ export default (/* eslint-disable @stylistic/indent */
 
 	return {
 		...importPlugin.flatConfigs.recommended,
+
 		rules,
-		/* eslint-disable @stylistic/indent */
+
+		/* eslint-disable @stylistic/indent, no-useless-escape */
 		settings: typescript
-			? importPlugin.flatConfigs.typescript.settings
-			: {'import/extensions': extensions,
-			   'import/resolver'  : {node: {extensions: [...extensions, '.json', '.jsonc']}},
-			   'import/ignore'    : ['\.(scss|less|css)$']} /* eslint-enable @stylistic/indent */
+		          ? importPlugin.flatConfigs.typescript.settings
+		          : {'import/extensions': extensions,
+		             'import/resolver'  : {node: {extensions: [...extensions, '.json', '.jsonc']}},
+		             'import/ignore'    : ['\.(scss|less|css)$']}
+		             /* eslint-enable @stylistic/indent, no-useless-escape */
 	};
 };

--- a/plugin-configs/eslint-plugin-import/format.js
+++ b/plugin-configs/eslint-plugin-import/format.js
@@ -5,8 +5,7 @@
  */
 
 // @ts-check
-/* eslint @stylistic/array-bracket-newline: ['warn', 'consistent']       -- good to understand. */
-/* eslint no-useless-escape: 'off' -- see `eslint-plugin-import` docs */
+/* eslint @stylistic/array-bracket-newline: ['warn', 'consistent'] -- good to understand. */
 
 import importPlugin from 'eslint-plugin-import-x';
 
@@ -81,12 +80,15 @@ export default (
 
 	return {
 		...importPlugin.flatConfigs.recommended,
+
 		rules,
-		/* eslint-disable @stylistic/indent */
+
+		/* eslint-disable @stylistic/indent, no-useless-escape */
 		settings: typescript
-			? importPlugin.flatConfigs.typescript.settings
-			: {'import/extensions': extensions,
-			   'import/resolver'  : {node: {extensions: [...extensions, '.json', '.jsonc']}},
-			   'import/ignore'    : ['\.(scss|less|css)$']} /* eslint-enable @stylistic/indent */
+		          ? importPlugin.flatConfigs.typescript.settings
+		          : {'import/extensions': extensions,
+		             'import/resolver'  : {node: {extensions: [...extensions, '.json', '.jsonc']}},
+		             'import/ignore'    : ['\.(scss|less|css)$']}
+		             /* eslint-enable @stylistic/indent, no-useless-escape */
 	};
 };

--- a/plugin-configs/eslint-plugin-n/rules/without-recommended.js
+++ b/plugin-configs/eslint-plugin-n/rules/without-recommended.js
@@ -63,6 +63,9 @@ export default (logLevel = 'error', {short = false} = {}) => ({
 	// Disallow synchronous methods
 	'n/no-sync': logLevel,
 
+	// Disallow top-level `await` in published modules
+	'n/no-top-level-await': [logLevel, {ignoreBin: true}],
+
 	...preferGlobal(logLevel),
 
 	// Enforce using the node: protocol when importing Node.js builtin modules.


### PR DESCRIPTION
| plugin name | old version | new version | added rules | info |
|--------|--------|--------|--------|--------|
| `eslint` | 9.26 | 9.28 | [`no-unassigned-vars`](https://eslint.org/blog/2025/05/eslint-v9.27.0-released/#new-rule-no-unassigned-vars)  | added rule options for TS support; [`max-params`](https://eslint.org/blog/2025/05/eslint-v9.27.0-released/#typescript-syntax-support-in-core-rules), [`func-style`, `no-magic-numbers`, `no-shadow`, `no-use-before-define`](https://eslint.org/blog/2025/05/eslint-v9.28.0-released/#typescript-syntax-support-in-core-rules)  |
| `@eslint/js` | 9.26 | removed | - | `eslint` depends on `@eslint/js` |
| `eslint-plugin-n` | 17.17 | 17.19 | [`no-top-level-await`](https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-top-level-await.md) | add `"engines"` field to `package.json` |
| `@stylistic/eslint` | 4.2 | 4.4 | - | [`jsx-sort-props`](https://eslint.style/rules/jsx-sort-props) has new options; [`reservedFirst`](https://eslint.style/rules/jsx-sort-props#reservedfirst) and [`reservedLast`](https://eslint.style/rules/jsx-sort-props#reservedlast) |
| `typescript-eslint` | 8.32 | 8.33 | - | [release note](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.33.0) |
